### PR TITLE
Add simplified JavaScript ECG simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,7 @@ PSD parameters: $f_1=.1$, $c_1=c_2=.01$, $f_2=.25$, LF/HF ratio $.5$
 RR tachgram for the above PSD with scaling for $RR$ mean $1.$ and $RR$ deviation equal to $.05$. The step plot shows the RR series that apply on the simulation.
 
 <img src="figs/rr.png" alt="drawing" width=""/>
+
+### JavaScript example
+
+A simplified JavaScript implementation is provided under `js/`. Open `js/index.html` in a browser to generate an example waveform using a small script that mimics the Python simulator.

--- a/js/ecg_simulator.js
+++ b/js/ecg_simulator.js
@@ -1,0 +1,55 @@
+// Simple ECG simulator for browser
+// This is a simplified JavaScript implementation inspired by the Python version
+// It generates a synthetic ECG using a sum of Gaussian functions for each wave.
+
+function simulateECG({
+    fs = 256,            // sampling frequency
+    hr = 60,             // mean heart rate (bpm)
+    duration = 10        // total time in seconds
+} = {}) {
+    const dt = 1 / fs;
+    const N = Math.floor(duration * fs);
+    // Wave parameters (approximate values)
+    const Ti = [ -Math.PI / 3, -Math.PI / 12, 0, Math.PI / 12, Math.PI / 2 ];
+    const ai = [ 1.2, -5.0, 30.0, -7.5, 0.75 ];
+    const bi = [ 0.25, 0.1, 0.1, 0.1, 0.4 ];
+
+    let theta = 0;
+    let z = 0;
+    const ecg = new Array(N);
+
+    for (let i = 0; i < N; i++) {
+        const w = 2 * Math.PI * hr / 60;
+        let dzdt = 0;
+        for (let j = 0; j < Ti.length; j++) {
+            let d = (theta - Ti[j] + Math.PI) % (2 * Math.PI) - Math.PI;
+            dzdt += ai[j] * Math.exp(-0.5 * Math.pow(d / bi[j], 2)) * (-d / (bi[j] * bi[j]));
+        }
+        dzdt *= w;
+        z += dzdt * dt;
+        theta += w * dt;
+        ecg[i] = z;
+    }
+
+    return ecg;
+}
+
+function drawECG(canvasId, data, fs) {
+    const canvas = document.getElementById(canvasId);
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const scaleX = canvas.width / data.length;
+    const min = Math.min(...data);
+    const max = Math.max(...data);
+    const scaleY = canvas.height / (max - min);
+    ctx.beginPath();
+    for (let i = 0; i < data.length; i++) {
+        const x = i * scaleX;
+        const y = canvas.height - (data[i] - min) * scaleY;
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = '#000';
+    ctx.stroke();
+}
+
+export { simulateECG, drawECG };

--- a/js/index.html
+++ b/js/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ECG Simulator</title>
+<style>
+  canvas { width: 100%; height: 300px; border: 1px solid #ccc; }
+</style>
+</head>
+<body>
+<h1>ECG Simulator (JavaScript)</h1>
+<canvas id="ecg" width="800" height="300"></canvas>
+<script type="module">
+import { simulateECG, drawECG } from './ecg_simulator.js';
+const data = simulateECG({ fs: 256, hr: 60, duration: 10 });
+drawECG('ecg', data, 256);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a JavaScript browser demo under `js/`
- include index.html example
- document the new JavaScript example in README

## Testing
- `node -e "import('./js/ecg_simulator.js').then(m=>{const data=m.simulateECG({fs:256,hr:60,duration:1}); console.log(data.length);});"`