### PR TITLE
Fix default web ECG view and rhythms

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -65,6 +65,8 @@
             <option value="tachy">Tachycardia</option>
             <option value="afib">Atrial Fibrillation (A-Fib)</option>
             <option value="pvc">Premature Ventricular Contraction (PVC)</option>
+            <option value="vtach">Ventricular Tachycardia</option>
+            <option value="avdissociation">Complete Heart Block (AV Dissociation)</option>
             <option value="asystole">Asystole (flatline)</option>
         </select>
 

--- a/web/script.js
+++ b/web/script.js
@@ -603,4 +603,4 @@ leadSelect.addEventListener('change',()=>{
 });
 
 loadCase('Normal Sinus Rhythm');
-animate();
+resetAndStartECG();


### PR DESCRIPTION
## Summary
- automatically start the ECG on page load
- include missing rhythm options for advanced scenarios

## Testing
- `pytest -q` *(fails: command not found)*